### PR TITLE
Fixed package prefix to com.ctrlplusz

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ unzip the .apklib, and reference the extracted project.
 ```
 use
 ```xml
-<com.ctrplusz.anytextview.AnyTextView 
+<com.ctrlplusz.anytextview.AnyTextView 
 	foobar:typeface="FontFileName.ttf" ..> <!-- Where "foobar" is the namespace defined in step 2 -->
 
 <!-- ... or ... -->
 
-<com.ctrplusz.anytextview.AnyEditTextView 
+<com.ctrlplusz.anytextview.AnyEditTextView 
 	foobar:typeface="FontFileName.ttf" ..> 
 ```  
  


### PR DESCRIPTION
In usage sample the package name was:
`com.ctrplusz.anytextview.AnyTextView`

so it was missing 'l' letter in "ctrl". I have changed it to:
`com.ctrlplusz.anytextview.AnyTextView`

Cheers!
